### PR TITLE
Adjust knowledge search similarity threshold

### DIFF
--- a/src/services/knowledgeBaseService.ts
+++ b/src/services/knowledgeBaseService.ts
@@ -139,7 +139,7 @@ class KnowledgeBaseService {
       // Search for similar chunks using vector similarity
       const { data: chunks, error } = await supabase.rpc('search_knowledge_chunks', {
         query_embedding: queryEmbedding,
-        match_threshold: 0.7,
+        match_threshold: 0.9,
         match_count: limit
       });
 


### PR DESCRIPTION
## Summary
- increase similarity threshold when searching the knowledge base to 0.9

## Testing
- `npm test` *(fails: No tests found)*
- `npm run lint` *(fails: 29 errors, 3 warnings)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68696745cba883239bb3572a81cce25c