### PR TITLE
Switch to GPT-4o model

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 - **ממשק קדמי**: React 18, TypeScript, Tailwind CSS
 - **שרת אחורי**: Supabase (PostgreSQL)
 - **אימות**: Supabase Auth
-- **בינה מלאכותית**: OpenAI GPT-3.5 Turbo
+- **בינה מלאכותית**: OpenAI GPT-4o
 - **אנימציות**: Framer Motion
 - **אייקונים**: Heroicons
 - **ניתוב**: React Router

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -87,7 +87,7 @@ class AIService {
         'Authorization': `Bearer ${this.apiKey}`,
       },
       body: JSON.stringify({
-        model: 'gpt-3.5-turbo',
+        model: 'gpt-4o',
         messages: [{ role: 'user', content: prompt }],
         max_tokens: 1000,
         temperature: 0.3,


### PR DESCRIPTION
## Summary
- update frontend AI calls to use `gpt-4o`
- update README to document use of GPT-4o

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6869690048dc8323a5c2815c9cf37141