### PR TITLE
Add dynamic Render deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,14 @@ npm run lint
 npm run build
 ```
 
+## פריסה ל-Render
+
+קובץ `render.yaml` שבמאגר מגדיר שני שירותים ל-Render:
+1. **optisupport-backend** – שירות web שמריץ את שרת Node מתוך התיקייה `backend`.
+2. **optisupport-frontend** – שירות web המבצע build לאפליקציית React ומריץ את `server.js` כדי להגיש את התיקייה `dist`.
+
+ייבוא המאגר כ-Blueprint ב-Render ייצור את שני השירותים באופן אוטומטי. יש להזין את משתני הסביבה הרלוונטיים בממשק Render בעת הפריסה.
+
 ## תרומה
 
 1. עשה fork למאגר

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "lint": "eslint .",
     "preview": "vite preview",
+    "start": "node server.js",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:coverage": "jest --coverage"

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,19 @@
+services:
+  - type: web
+    name: optisupport-backend
+    env: node
+    rootDir: backend
+    buildCommand: "npm install"
+    startCommand: "npm start"
+    envVars:
+      - key: NODE_VERSION
+        value: 18
+  - type: web
+    name: optisupport-frontend
+    env: node
+    rootDir: .
+    buildCommand: "npm install && npm run build"
+    startCommand: "npm start"
+    envVars:
+      - key: NODE_VERSION
+        value: 18

--- a/server.js
+++ b/server.js
@@ -1,0 +1,17 @@
+import express from 'express';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+app.use(express.static(join(__dirname, 'dist')));
+
+app.get('*', (req, res) => {
+  res.sendFile(join(__dirname, 'dist', 'index.html'));
+});
+
+app.listen(PORT, () => {
+  console.log(`Frontend server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add Node-based server for React build
- configure front-end as web service in render.yaml
- document dynamic front-end deployment

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869aaa05d848323b0a92555207026ee