### PR TITLE
Update AI model to GPT-4o

### DIFF
--- a/backend/src/services/aiService.js
+++ b/backend/src/services/aiService.js
@@ -33,7 +33,7 @@ export const analyzeUrgency = async (text) => {
     const response = await axios.post(
       'https://api.openai.com/v1/chat/completions',
       {
-        model: 'gpt-3.5-turbo',
+        model: 'gpt-4o',
         messages: [
           { 
             role: 'system', 

--- a/src/services/aiService.ts
+++ b/src/services/aiService.ts
@@ -89,7 +89,7 @@ class AIService {
 
     try {
       const chatResponse = await this.openai.chat.completions.create({
-        model: 'gpt-4.1-2025-04-14',
+        model: 'gpt-4o',
         messages: [{ role: 'user', content: prompt }],
         max_tokens: 1000,
         temperature: 0.3,


### PR DESCRIPTION
## Summary
- switch AI model to `gpt-4o` in both frontend and backend services

## Testing
- `npm test -- --passWithNoTests`
- `npm run lint` *(fails: 34 errors, 3 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_686ae693d38c8323a8042dc7c6b910fc